### PR TITLE
Change response types to ensure proper status and headers are set

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './errors';
 export * from './openapi';
+export * from './response';

--- a/packages/lib/src/openapi.ts
+++ b/packages/lib/src/openapi.ts
@@ -254,8 +254,10 @@ export class OpenApi<T> {
 
       // Note: The handler function may modify the "res" object and/or return a response body.
       // If "res.body" is undefined we use the return value as the body.
-      const resBody = await operationHandler(req, res, operationParams);
-      res.body = res.body ?? resBody;
+      const returnedResponse = await operationHandler(req, res, operationParams);
+      if (returnedResponse !== undefined) {
+        Object.assign(res, returnedResponse);
+      }
 
       // If status code is not specified and a non-ambiguous default status code is available, use it
       res.statusCode = res.statusCode ?? this.getDefaultStatusCode(operation);

--- a/packages/lib/src/response.ts
+++ b/packages/lib/src/response.ts
@@ -1,0 +1,16 @@
+export function json<T>(body: T): { statusCode: 200; body: T; headers: { "Content-Type": "application/json" } };
+export function json<T, CT extends number>(body: T, status: CT): { statusCode: CT; body: T; headers: { "Content-Type": "application/json" } };
+
+export function json<T, CT extends number = 200>(
+    body: T,
+    status?: CT
+): {statusCode: CT | 200; body: T; headers: { "Content-Type": "application/json" } } {
+    const statusCode = status ?? 200
+    return {
+        statusCode,
+        body,
+        headers: {
+            "Content-Type": "application/json",
+        },
+    }
+}

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -103,9 +103,8 @@ export type RequestHandler<P = unknown,
     Req extends Request = Request,
     Res extends Response = Response> = (
         req: Req,
-        res: Res,
-        params: P) => Awaitable<Res['body'] | void>;
-
+        res: Response,
+        params: P) => Awaitable<Res | void>;
 
 type SecuritySchemeObject = OpenAPIV3_1.SecuritySchemeObject | OpenAPIV3.SecuritySchemeObject;
 /**

--- a/packages/test/api.yml
+++ b/packages/test/api.yml
@@ -152,6 +152,37 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+  '/multiresponse':
+    get:
+      operationId: multiResponse
+      summary: test multiple possible responses
+      parameters:
+        - in: query
+          name: type
+          schema:
+            type: string
+
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  okBody:
+                    type: number
+            text/html:
+              schema:
+                type: string
+
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+
 
 
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -2,7 +2,7 @@
   "name": "test",
   "scripts": {
     "pretest": "npm -w ../lib run build && openapi-ts-backend generate-types api.yml src/gen",
-    "test": "LOG_LEVEL=${LOG_LEVEL:=error} jest"
+    "test": "tsc && LOG_LEVEL=${LOG_LEVEL:=error} jest"
   },
   "devDependencies": {
     "@openapi-ts/cli": "*",

--- a/packages/test/src/openapi.test.ts
+++ b/packages/test/src/openapi.test.ts
@@ -1,4 +1,4 @@
-import {HttpError, OpenApi} from "@openapi-ts/backend";
+import {HttpError, json, OpenApi} from "@openapi-ts/backend";
 import { OperationHandlers} from './gen';
 
 function greet(title: string, name: string): string {
@@ -13,23 +13,43 @@ const operations: OperationHandlers<unknown> = {
   greet: req => {
     const {params: {name}, query: {title = ''}} = req;
 
-    return {
-      message: greet(title, name),
-    };
+    return json({ message: greet(title, name)})
   },
   addPerson: req => {
-    return req.body.person;
+    return json(req.body.person, 201);
   },
   getTypes: req => {
-    return {
+    return json({
       params: getTypeMap(req.params),
       headers: getTypeMap(req.headers),
       query: getTypeMap(req.query),
       cookies: getTypeMap(req.cookies),
-    }
+    })
   },
   deletePerson: () => {
     return;
+  },
+  multiResponse: (req) => {
+    if (req.query.type === '') {
+        return {
+            statusCode: 404,
+            body: {},
+            headers: {
+                'Content-Type': 'application/json',
+                'Additional-Header': 'somethingelse'
+            }
+        }
+    }
+    if (req.query.type === 'html') {
+        return {
+            statusCode: 200,
+            body: 'htmlContent',
+            headers: {
+                'Content-Type': 'text/html'
+            }
+        }
+    }
+    return json({ okBody: 1337 })
   }
 };
 

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "noEmit": true,
+    "noEmit": true
   },
+  "exclude": ["jest.config.ts"]
 }


### PR DESCRIPTION
Hi Henrik,

thanks again for your great library!

One thing that was bothering me when working with it was that I kept forgetting to set the correct content type for the responses and then diligent tools (like when using supertest I think) said "what `body`? there is no json here!".

So I thought "can't be too hard to fix this, we have the complete api definition!". Turns out my TypeScript foo is not as great as I hoped, so I employed ChatGPTs help for figuring out the correct shapes. It was a give and take though, as I manually had to fix a couple things.

So the type system now makes you return the complete response (`statusCode`, `body`, `content-type`), not only the body. And the type system enforces that those match the api definition.

Would love to get your thoughts on this experiment! It does make things a bit stiffer, but I think with the `json` helper I introduced it should not be much more verbose in most common api usecases.